### PR TITLE
Migration of publishing process

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,13 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion = rootProject.ext.compileSdkVersion
     buildToolsVersion = rootProject.ext.buildToolsVersion
+
+    namespace 'com.monri.android.example'
+
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         applicationId "com.monri.android.example"
         minSdkVersion 19

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.monri.android.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         google()
@@ -10,7 +9,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip

--- a/monri/build.gradle
+++ b/monri/build.gradle
@@ -1,11 +1,20 @@
-apply plugin: 'com.android.library'
-apply plugin: 'maven-publish'
-apply plugin: 'signing'
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
+plugins {
+    id "com.vanniktech.maven.publish" version "0.33.0"
+    id 'com.android.library'
+}
 
 android {
     compileSdkVersion = rootProject.ext.compileSdkVersion
     buildToolsVersion = rootProject.ext.buildToolsVersion
-    
+
+    namespace 'com.monri.android'
+
+    buildFeatures {
+        buildConfig = true
+    }
+
     repositories {
         maven { url 'https://repo1.maven.org/maven2' }
     }
@@ -59,60 +68,45 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            release(MavenPublication) {
-                from components.release
-                groupId = 'com.monri'
-                artifactId = 'monri-android'
-                version = rootProject.ext.monriSdkVersion
-                pom {
-                    name = 'Monri'
-                    description = 'Monri Android SDK'
-                    url = 'https://github.com/MonriPayments/monri-android'
-                    licenses {
-                        license {
-                            name = 'MIT License'
-                            url = 'https://github.com/MonriPayments/monri-android/blob/master/LICENSE'
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = 'jasminsuljic'
-                            name = 'Jasmin Suljic'
-                            email = 'jasmin.suljic@monri.com'
-                        }
-                        developer {
-                            id = 'adnanomerovic'
-                            name = 'Adnan Omerovic'
-                            email = 'adnan.omerovic@monri.com'
-                        }
-                    }
-                    scm {
-                        connection = 'https://github.com/MonriPayments/monri-android'
-                        developerConnection = 'git@github.com:MonriPayments/monri-android.git'
-                        url = 'https://github.com/MonriPayments/monri-android'
-                    }
-                }
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+
+    configure(new AndroidSingleVariantLibrary("release", false, false))
+
+    def groupId = 'com.monri'
+    def artifactId = 'monri-android'
+    def version = rootProject.ext.monriSdkVersion
+
+    coordinates(groupId, artifactId, version)
+
+    pom {
+        name = 'Monri'
+        description = 'Monri Android SDK'
+        url = 'https://github.com/MonriPayments/monri-android'
+        licenses {
+            license {
+                name = 'MIT License'
+                url = 'https://github.com/MonriPayments/monri-android/blob/master/LICENSE'
             }
         }
-        repositories {
-            maven {
-                name = 'SonaType'
-                def releasesRepoUrlStaging = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-                def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-                def releasesRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/releases/'
-                //without close and release on nexus
-                url = rootProject.ext.monriSdkVersion.endsWith('SNAPSHOT') || System.getProperty("snapshot") ? snapshotsRepoUrl : releasesRepoUrlStaging
-                credentials {
-                    username project.findProperty("mavenCentralRepositoryUsername") ?: System.getenv('mavenCentralRepositoryUsername') ?: ''
-                    password project.findProperty("mavenCentralRepositoryPassword") ?: System.getenv('mavenCentralRepositoryPassword') ?: ''
-                }
+        developers {
+            developer {
+                id = 'jasminsuljic'
+                name = 'Jasmin Suljic'
+                email = 'jasmin.suljic@monri.com'
+            }
+            developer {
+                id = 'adnanomerovic'
+                name = 'Adnan Omerovic'
+                email = 'adnan.omerovic@monri.com'
             }
         }
-    }
-    signing {
-        sign publishing.publications.release
+        scm {
+            connection = 'https://github.com/MonriPayments/monri-android'
+            developerConnection = 'git@github.com:MonriPayments/monri-android.git'
+            url = 'https://github.com/MonriPayments/monri-android'
+        }
     }
 }
+

--- a/monri/src/main/AndroidManifest.xml
+++ b/monri/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.monri.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 


### PR DESCRIPTION
Use 3rd party plugin for publishing to maven central portal because of ossrh deprecation
Update to agp 8
Update to gradle 8.5