### PR TITLE
Bugfix/payment controller npe

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We support Android 4.4 (API level 19) and above.
 Installing the Monri Android library is simple using  [Android Studio](https://developer.android.com/studio/intro)  and  [IntelliJ](https://www.jetbrains.com/help/idea/getting-started-with-android-development.html). You don’t need to clone a repo or download any files. Just add the following to your project’s  `build.gradle`  file, inside the dependencies section.
 
 ```gradle
-implementation 'com.monri:monri-android:3.2.1'
+implementation 'com.monri:monri-android:3.2.2'
 ```
 
 ## Proguard rules

--- a/app/src/main/java/com/monri/android/example/PaymentPickerActivity.java
+++ b/app/src/main/java/com/monri/android/example/PaymentPickerActivity.java
@@ -103,6 +103,8 @@ public class PaymentPickerActivity extends AppCompatActivity implements ResultCa
         }
 
         directPaymentViewSetup();
+
+        monri.setPaymentResultConsumer(this::showPaymentResult);
     }
 
     private void savedCardPaymentViewSetup(Intent intent) {
@@ -206,17 +208,19 @@ public class PaymentPickerActivity extends AppCompatActivity implements ResultCa
                                 .set(customerParams)
                 );
 
-                monri.confirmPayment(confirmPaymentParams, (result, throwable) -> {
-                    if (throwable != null) {
-                        txtViewResult.setText(String.format("%s%n%n%s", throwable.getCause(), Arrays.toString(throwable.getStackTrace())));
-                        Toast.makeText(this, throwable.getMessage(), Toast.LENGTH_LONG).show();
-                    } else {
-                        Toast.makeText(this, String.format("Transaction processed with result %s", result.getStatus()), Toast.LENGTH_LONG).show();
-                        txtViewResult.setText(result.toString());
-                    }
-                });
+                monri.confirmPayment(confirmPaymentParams, this::showPaymentResult);
             }
         };
+    }
+
+    private void showPaymentResult(final PaymentResult result, final Throwable throwable) {
+        if (throwable != null) {
+            txtViewResult.setText(String.format("%s%n%n%s", throwable.getCause(), Arrays.toString(throwable.getStackTrace())));
+            Toast.makeText(this, throwable.getMessage(), Toast.LENGTH_LONG).show();
+        } else if (result != null) {
+            Toast.makeText(this, String.format("Transaction processed with result %s", result.getStatus()), Toast.LENGTH_LONG).show();
+            txtViewResult.setText(result.toString());
+        }
     }
 
     PaymentMethodParams nonThreeDsCard() {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext {
     junitVersion = "4.13.2"
     mockitoCoreVersion = "3.9.0"
     robolectricVersion = '4.16'
-    monriSdkVersion = '3.2.1'
+    monriSdkVersion = '3.2.2'
 
     googlePlayServicesWalletVersion = '19.4.0'
 }

--- a/monri/src/main/java/com/monri/android/Monri.java
+++ b/monri/src/main/java/com/monri/android/Monri.java
@@ -39,6 +39,9 @@ public final class Monri {
     private MonriApi monriApi;
     private final ActivityResultLauncher<ConfirmPaymentActivity.Request> registeredForActivityResult;
     private PaymentController paymentController;
+    private ActionResultConsumer<PaymentResult> paymentResultConsumer;
+    private PaymentResult pendingPaymentResult;
+    private boolean hasPendingPaymentResult;
 
     @VisibleForTesting
     private
@@ -81,7 +84,7 @@ public final class Monri {
     public Monri(final ActivityResultCaller activityResultCaller) {
         registeredForActivityResult = activityResultCaller.registerForActivityResult(
                 new ConfirmPaymentActivityResultContract(),
-                result -> paymentController.acceptResult(result.getPaymentResult(), null)
+                result -> deliverPaymentResult(result == null ? null : result.getPaymentResult())
         );
     }
 
@@ -146,6 +149,30 @@ public final class Monri {
                                final GooglePayButtonOptions googlePayButtonOptions)
     {
         paymentController.confirmPayment(confirmPaymentParams, callback, googlePayButtonOptions);
+    }
+
+    public void setPaymentResultConsumer(@NonNull final ActionResultConsumer<PaymentResult> consumer) {
+        paymentResultConsumer = consumer;
+
+        if (hasPendingPaymentResult) {
+            hasPendingPaymentResult = false;
+
+            final PaymentResult result = pendingPaymentResult;
+            pendingPaymentResult = null;
+
+            consumer.accept(result, null);
+        }
+    }
+
+    private void deliverPaymentResult(final PaymentResult paymentResult) {
+        if (paymentController != null && paymentController.hasResultConsumer()) {
+            paymentController.acceptResult(paymentResult, null);
+        } else if (paymentResultConsumer != null) {
+            paymentResultConsumer.accept(paymentResult, null);
+        } else {
+            pendingPaymentResult = paymentResult;
+            hasPendingPaymentResult = true;
+        }
     }
 
     private void tokenTaskPostExecution(ResponseWrapper result, TokenCallback callback) {

--- a/monri/src/main/java/com/monri/android/MonriPaymentController.java
+++ b/monri/src/main/java/com/monri/android/MonriPaymentController.java
@@ -5,6 +5,8 @@ import android.content.Intent;
 import androidx.activity.result.ActivityResultLauncher;
 import com.monri.android.activity.ConfirmPaymentActivity;
 import com.monri.android.googlepay.GooglePayButtonOptions;
+import com.monri.android.logger.MonriLogger;
+import com.monri.android.logger.MonriLoggerFactory;
 import com.monri.android.model.ConfirmPaymentParams;
 import com.monri.android.model.MonriApiOptions;
 import com.monri.android.model.PaymentResult;
@@ -14,6 +16,11 @@ import com.monri.android.model.PaymentResult;
  * MonriAndroid
  */
 final class MonriPaymentController implements PaymentController {
+
+    private static final MonriLogger logger = MonriLoggerFactory.get("MonriPaymentController");
+
+    private static final String NO_CALLBACK_ATTACHED_WARNING = "PaymentResult received but no confirmPayment callback is attached. " +
+            "Use Monri#setPaymentResultConsumer to receive results after activity recreation.";
 
     private final int PAYMENT_REQUEST_CODE = 10000;
     private final int AUTHENTICATE_PAYMENT_REQUEST_CODE = 10001;
@@ -85,11 +92,19 @@ final class MonriPaymentController implements PaymentController {
     }
 
     @Override
-    public void acceptResult(PaymentResult result, Throwable throwable) {
-        if (delegatedCallback == null) {
-             throw new NullPointerException("delegatedCallback is null");
+    public void acceptResult(final PaymentResult result, final Throwable throwable) {
+        final ActionResultConsumer<PaymentResult> callback = delegatedCallback;
+        delegatedCallback = null;
+
+        if (callback == null) {
+            logger.warn(NO_CALLBACK_ATTACHED_WARNING);
         } else {
-            delegatedCallback.accept(result, throwable);
+            callback.accept(result, throwable);
         }
+    }
+
+    @Override
+    public boolean hasResultConsumer() {
+        return delegatedCallback != null;
     }
 }

--- a/monri/src/main/java/com/monri/android/PaymentController.java
+++ b/monri/src/main/java/com/monri/android/PaymentController.java
@@ -25,4 +25,8 @@ public interface PaymentController {
     void handlePaymentResult(int requestCode, Intent data, ResultCallback<PaymentResult> callback);
 
     void acceptResult(PaymentResult result, Throwable throwable);
+
+    default boolean hasResultConsumer() {
+        return false;
+    }
 }


### PR DESCRIPTION
Adding fix for payment controller NPE - during 3ds flow if the client activity was destroyed / recreated, while Monri's ConfirmPaymentActivity / webview was displayed, the Monri instance within the client activity would get recreated and paymentController / delegated callback would be null - causing an NPE and making the client activity unable to receive a result